### PR TITLE
[Feat] Export parser

### DIFF
--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -31,8 +31,14 @@ fn traverse_module(file_path: &String, content: &mut String, module_map: Rc<Hash
 
   let mut parent_path_buf = RelativePathBuf::from(file_path.as_str());
   parent_path_buf.pop();
+
   for import in module.imports.iter() {
     let mod_path = parent_path_buf.join_normalized(RelativePath::new(&import.specifier));
+    traverse_module(&mod_path.to_string(), content, Rc::clone(&module_map));
+  }
+
+  for export in module.exports.iter() {
+    let mod_path = parent_path_buf.join_normalized(RelativePath::new(&export.specifier));
     traverse_module(&mod_path.to_string(), content, Rc::clone(&module_map));
   }
 

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -56,6 +56,15 @@ fn traverse_module(file_path: &String, content: &mut String, module_map: Rc<Hash
     last_index = import.specifier_end + 1;
   }
 
+  for export in module.exports.iter() {
+    let mod_path = parent_path_buf.join_normalized(RelativePath::new(&export.specifier));
+    content.push_str(module.raw_source.get(last_index..export.specifier_start).unwrap());
+    content.push_str("${resolveImportSpecifier(\"");
+    content.push_str(&mod_path.to_string().as_str());
+    content.push_str("\")}");
+    last_index = export.specifier_end + 1;
+  }
+
   if last_index < module.raw_source.len() {
     content.push_str(module.raw_source.get(last_index..module.raw_source.len()).unwrap());
   }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -467,9 +467,6 @@ impl JavascriptLexer {
             self.indices_to_skip = 1;
             pending_export.expected_token = ExportToken::NamedExport;
           },
-          c if c.is_whitespace() => {
-            self.keep_using_handler();
-          },
           _ => {
             panic!(format!("Invalid character '{}' at index {} - expected ',' or keyword 'as' or '}}'", self.current_char, self.current_index));
           }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -285,7 +285,6 @@ impl JavascriptLexer {
         } else {
           match self.current_char {
             '\u{0030}'..='\u{E01EF}' => {
-              dbg!(self.current_char);
                // still parsing the NamedImport
             },
             _ => {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -9,19 +9,27 @@ pub struct JavascriptModule {
 }
 
 #[derive(Debug)]
-pub struct JavascriptExport {
-  pub export_name: String,
-}
-
 enum ImportToken {
-  Variables,
+  Variables, // represents a block of possible NamedImports or DefaultImports
   From,
   Specifier,
+  DefaultImport,
   NamedImport,
   NextNamedImport,
   StatementEnd,
 }
 
+#[derive(Debug)]
+enum ExportToken {
+  Variables,
+  From,
+  Specifier,
+  NamedExport,
+  NextNamedExport,
+  StatementEnd,
+}
+
+#[derive(Debug)]
 struct PendingJavascriptImport {
   import: JavascriptImport,
   expected_token: ImportToken,
@@ -29,9 +37,19 @@ struct PendingJavascriptImport {
   str_char: Option<char>,
 }
 
+// TODO: Backtracking to ensure there is a specifier
+#[derive(Debug)]
+struct PendingJavascriptExport {
+  export: JavascriptExport,
+  expected_token: ExportToken,
+  token_start: Option<usize>,
+  str_char: Option<char>,
+}
+
 #[derive(Debug)]
 pub struct JavascriptImport {
   pub default_name: Option<String>,
+  pub default_import: Option<DefaultImport>,
   pub named_imports: Vec<NamedImport>,
   pub specifier: String,
   pub specifier_start: usize,
@@ -39,9 +57,30 @@ pub struct JavascriptImport {
 }
 
 #[derive(Debug)]
+pub struct DefaultImport {
+  variable_name: String,
+  binding_name: String
+}
+
+#[derive(Debug)]
 pub struct NamedImport {
   variable_name: String,
   binding_name: String
+}
+
+#[derive(Debug)]
+pub struct JavascriptExport {
+  pub default_name: Option<String>,
+  pub named_exports: Vec<NamedExport>,
+  pub specifier: String,
+  pub specifier_start: usize,
+  pub specifier_end: usize,
+}
+
+#[derive(Debug)]
+pub struct NamedExport {
+  variable_name: String,
+  binding_name: String // TODO: what is the difference?
 }
 
 pub struct JavascriptLexer {
@@ -52,12 +91,14 @@ pub struct JavascriptLexer {
   handler_stack: Vec<Handler>,
   current_handler: Handler,
   pending_import: Option<PendingJavascriptImport>,
+  pending_export: Option<PendingJavascriptExport>,
 }
 
 #[derive(Clone, Copy, AsRefStr, Debug)]
 enum Handler {
   Normal,
   Import,
+  Export,
 }
 
 #[derive(Clone, Copy)]
@@ -76,7 +117,8 @@ impl JavascriptLexer {
       indices_to_skip: 0,
       handler_stack: Vec::new(),
       current_handler: Handler::Normal,
-      pending_import: None
+      pending_import: None,
+      pending_export: None
     }
   }
 
@@ -110,6 +152,7 @@ impl JavascriptLexer {
       match self.current_handler {
         Handler::Normal => self.handle_normal(&mut js_module),
         Handler::Import => self.handle_import(&mut js_module),
+        Handler::Export => self.handle_export(&mut js_module),
       }
     }
 
@@ -136,6 +179,30 @@ impl JavascriptLexer {
               import: JavascriptImport {
                 default_name: None,
                 named_imports: Vec::new(),
+                default_import: None,
+                specifier: String::new(),
+                specifier_start: 0,
+                specifier_end: 0,
+              },
+              token_start: None,
+              str_char: None,
+            });
+          },
+          _ => {
+            self.keep_using_handler();
+          }
+        }
+      },
+      'e' => {
+        match self.source.get(self.current_index..self.current_index + 6).unwrap_or("") {
+          "export" => {
+            self.queue_handler(Handler::Export);
+            self.indices_to_skip = 5;
+            self.pending_export = Some(PendingJavascriptExport {
+              expected_token: ExportToken::Variables,
+              export: JavascriptExport {
+                default_name: None,
+                named_exports: Vec::new(),
                 specifier: String::new(),
                 specifier_start: 0,
                 specifier_end: 0,
@@ -164,10 +231,41 @@ impl JavascriptLexer {
           '{' => {
             pending_import.expected_token = ImportToken::NamedImport;
           },
+          '\u{0041}'..='\u{2FA1D}' => {
+            pending_import.expected_token = ImportToken::DefaultImport;
+            pending_import.token_start = Some(self.current_index);
+          }
           _ => {
+              // is_whitespace
           }
         }
 
+        self.keep_using_handler();
+      },
+      ImportToken::DefaultImport => {
+        match self.current_char {
+          '\u{0030}'..='\u{E01EF}' => {}, // still parsing the DefaultImport
+          _ => {
+            let identifier = String::from(self.source.get(pending_import.token_start.unwrap()..self.current_index).unwrap());
+            let default_import = DefaultImport {
+              variable_name: identifier.clone(),
+              binding_name: identifier,
+            };
+            pending_import.import.default_import = Some(default_import);
+            let next_token;
+            match self.current_char {
+              // ',' => {
+              //   next_token = ImportToken::NamedImport;
+              // },
+              _ => {
+                // whitespace
+                next_token = ImportToken::From;
+              }
+            }
+            pending_import.expected_token = next_token;
+            pending_import.token_start = None;
+          }
+        }
         self.keep_using_handler();
       },
       ImportToken::NamedImport => {
@@ -183,7 +281,7 @@ impl JavascriptLexer {
           }
         } else {
           match self.current_char {
-            '\u{0030}'..='\u{E01EF}' => {},
+            '\u{0030}'..='\u{E01EF}' => {}, // still parsing the NamedImport
             _ => {
               let identifier = String::from(self.source.get(pending_import.token_start.unwrap()..self.current_index).unwrap());
               let named_import = NamedImport {
@@ -200,6 +298,7 @@ impl JavascriptLexer {
                   next_token = ImportToken::NamedImport;
                 },
                 _ => {
+                  // whitespace
                   next_token = ImportToken::NextNamedImport;
                 }
               }
@@ -250,8 +349,7 @@ impl JavascriptLexer {
       ImportToken::Specifier => {
         if pending_import.token_start.is_none() {
           match self.current_char {
-            c if c.is_whitespace() => {
-            },
+            c if c.is_whitespace() => {},
             '\'' | '"' => {
               pending_import.token_start = Some(self.current_index + 1);
               pending_import.str_char = Some(self.current_char);
@@ -276,9 +374,160 @@ impl JavascriptLexer {
       },
       ImportToken::StatementEnd => {
         match self.current_char {
-          c if c.is_whitespace() => {},
+          c if c == ' ' => {},
           ';' | '\n' | '\r' => {
             js_module.imports.push(self.pending_import.take().unwrap().import);
+            self.queue_handler(Handler::Normal);
+          },
+          _ => {
+            panic!(format!("Invalid character '{}' at index {} - expected statement end", self.current_char, self.current_index));
+          }
+        }
+      },
+    }
+  }
+
+  fn handle_export(&mut self, js_module: &mut JavascriptModule) {
+    let mut pending_export = self.pending_export.as_mut().unwrap();
+
+    match pending_export.expected_token {
+      ExportToken::Variables => {
+        match self.current_char {
+          '{' => {
+            pending_export.expected_token = ExportToken::NamedExport;
+          },
+          _ => {
+          }
+        }
+
+        self.keep_using_handler();
+      },
+      ExportToken::NamedExport => {
+        if pending_export.token_start.is_none() {
+          match self.current_char {
+            c if c.is_whitespace() => {},
+            '\u{0041}'..='\u{2FA1D}' => {
+              pending_export.token_start = Some(self.current_index);
+            },
+            _ => {
+              panic!(format!("Invalid character '{}' at index {} - expected identifier start", self.current_char, self.current_index));
+            }
+          }
+        } else {
+          match self.current_char {
+            '\u{0030}'..='\u{E01EF}' => {},
+            _ => {
+              let identifier = String::from(self.source.get(pending_export.token_start.unwrap()..self.current_index).unwrap());
+              if identifier == "default" { // TODO: this can be improved.  "default as" w/ backtracking?
+                  // reset since next identifier will rename "export { default as ... }"
+                  pending_export.token_start = None;
+                  pending_export.expected_token = ExportToken::NextNamedExport;
+              } else {
+                  let named_export = NamedExport {
+                    variable_name: identifier.clone(),
+                    binding_name: identifier,
+                  };
+                  pending_export.export.named_exports.push(named_export);
+                  let next_token;
+                  match self.current_char {
+                    '}' => {
+                      next_token = ExportToken::From;
+                    },
+                    ',' => {
+                      next_token = ExportToken::NamedExport;
+                    },
+                    _ => {
+                      next_token = ExportToken::NextNamedExport;
+                    }
+                  }
+                  pending_export.expected_token = next_token;
+                  pending_export.token_start = None;
+              }
+            }
+          }
+        }
+        self.keep_using_handler();
+      },
+      ExportToken::NextNamedExport => {
+        match self.current_char {
+          '}' => {
+            pending_export.expected_token = ExportToken::From;
+          },
+          ',' => {
+            pending_export.expected_token = ExportToken::NamedExport;
+          },
+          'a' => {
+            // re-export: `export { default as b } from './b';`
+            self.indices_to_skip = 1;
+            pending_export.expected_token = ExportToken::NamedExport;
+          },
+          c if c.is_whitespace() => {
+            self.keep_using_handler();
+          },
+          _ => {
+            panic!(format!("Invalid character '{}' at index {} - expected ',' or '}}'", self.current_char, self.current_index));
+          }
+        }
+        self.keep_using_handler();
+      },
+      ExportToken::From => {
+        match self.current_char {
+          c if c.is_whitespace() => {},
+          'f' => {
+            match self.source.get(self.current_index..self.current_index+4).unwrap_or("f") {
+              "from" => {
+                self.indices_to_skip = 3;
+                pending_export.expected_token = ExportToken::Specifier;
+              },
+              _ => {
+                panic!(format!("Invalid character '{}' at index {} - expected keyword 'from'", self.current_char, self.current_index));
+              }
+            }
+          },
+          ';' => {
+            // export { b };
+            // This ended up not being an export with a specifier
+            self.pending_export = None;
+            self.queue_handler(Handler::Normal);
+            return;
+          }
+          _ => {
+            panic!(format!("Invalid character '{}' at index {} - expected keyword 'from'", self.current_char, self.current_index));
+          }
+        }
+        self.keep_using_handler();
+      },
+      ExportToken::Specifier => {
+        if pending_export.token_start.is_none() {
+          match self.current_char {
+            c if c.is_whitespace() => {},
+            '\'' | '"' => {
+              pending_export.token_start = Some(self.current_index + 1);
+              pending_export.str_char = Some(self.current_char);
+              pending_export.expected_token = ExportToken::Specifier;
+              pending_export.export.specifier_start = self.current_index + 1;
+            },
+            _ => {
+              panic!(format!("Invalid character '{}' at index {} - expected string start ' or \"", self.current_char, self.current_index));
+            }
+          }
+        } else {
+          match self.current_char {
+            c if c == pending_export.str_char.unwrap() => {
+              pending_export.export.specifier = String::from(self.source.get(pending_export.token_start.unwrap()..self.current_index).unwrap());
+              pending_export.expected_token = ExportToken::StatementEnd;
+              pending_export.export.specifier_end = self.current_index - 1;
+            },
+            _ => {}
+          }
+        }
+        self.keep_using_handler();
+      },
+      ExportToken::StatementEnd => {
+        match self.current_char {
+          c if c == ' ' => {},
+          ';' | '\n' | '\r' => {
+            js_module.exports.push(self.pending_export.take().unwrap().export);
             self.queue_handler(Handler::Normal);
           },
           _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use std::fs;
 pub mod lexer;
 pub mod bundler;
 use std::collections::HashMap;
-// use std::path::{Path};
 use relative_path::{RelativePath, RelativePathBuf};
 use std::env::current_dir;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ fn traverse_file(file_path: String, mut module_map: HashMap<String, lexer::Javas
     let module: lexer::JavascriptModule = lexer::JavascriptLexer::new(source).parse_module();
 
     for import in module.imports.iter() {
-        let _parent_path = RelativePath::new(file_path.as_str());
         let mut parent_path_buf = RelativePathBuf::from(file_path.as_str());
         // remove filename + extension
         parent_path_buf.pop();

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ fn traverse_file(file_path: String, mut module_map: HashMap<String, lexer::Javas
     }
 
     for export in module.exports.iter() {
-        let _parent_path = RelativePath::new(file_path.as_str());
         let mut parent_path_buf = RelativePathBuf::from(file_path.as_str());
         parent_path_buf.pop();
         let mod_path = parent_path_buf.join_normalized(RelativePath::new(&export.specifier));

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::fs;
 pub mod lexer;
 pub mod bundler;
 use std::collections::HashMap;
-use std::path::{Path};
+// use std::path::{Path};
 use relative_path::{RelativePath, RelativePathBuf};
 use std::env::current_dir;
 
@@ -20,13 +20,24 @@ fn main() {
 fn traverse_file(file_path: String, mut module_map: HashMap<String, lexer::JavascriptModule>) -> HashMap<String, lexer::JavascriptModule> {
     let source = fs::read_to_string(file_path.clone()).expect(format!("Unable to read {}", file_path.clone()).as_str());
     let module: lexer::JavascriptModule = lexer::JavascriptLexer::new(source).parse_module();
+
     for import in module.imports.iter() {
-        let parent_path = RelativePath::new(file_path.as_str());
+        let _parent_path = RelativePath::new(file_path.as_str());
         let mut parent_path_buf = RelativePathBuf::from(file_path.as_str());
+        // remove filename + extension
         parent_path_buf.pop();
         let mod_path = parent_path_buf.join_normalized(RelativePath::new(&import.specifier));
         module_map = traverse_file(mod_path.to_string(), module_map);
     }
+
+    for export in module.exports.iter() {
+        let _parent_path = RelativePath::new(file_path.as_str());
+        let mut parent_path_buf = RelativePathBuf::from(file_path.as_str());
+        parent_path_buf.pop();
+        let mod_path = parent_path_buf.join_normalized(RelativePath::new(&export.specifier));
+        module_map = traverse_file(mod_path.to_string(), module_map);
+    }
+
     let full_path = RelativePath::new(file_path.as_str()).to_path(current_dir().unwrap().as_path()).to_str().unwrap().to_string();
 
     module_map.insert(full_path, module);

--- a/test/fixtures/bundle.js
+++ b/test/fixtures/bundle.js
@@ -3,23 +3,32 @@ insertModule("test/fixtures/src/b.js",createModuleUrl(`const b = 're-export';
 
 export { b };
 `));
-insertModule("test/fixtures/src/d.js",createModuleUrl(`const d = 're-export';
+insertModule("test/fixtures/src/e.js",createModuleUrl(`const e = 're-export e-aggregate';
+
+export { e };
+`));
+insertModule("test/fixtures/src/d.js",createModuleUrl(`const d = 're-export default';
 
 export default d;
 `));
+insertModule("test/fixtures/src/a-default.js",createModuleUrl(`const A = () => {};
+
+export { A };
+`));
 insertModule("test/fixtures/src/a.js",createModuleUrl(`export const a = 'a value';
-export const other = 'other value';
 
 export { b } from './b.js';
+export * from './e.js';
 export { default as DModule } from './d.js';
+export { A as default } from './a-default.js';
 `));
 insertModule("test/fixtures/src/c-default.js",createModuleUrl(`const c = 'default export';
 
 export default c;
 `));
-insertModule("test/fixtures/src/main.js",createModuleUrl(`import { a, b, DModule, other } from '${resolveImportSpecifier("test/fixtures/src/a.js")}';
+insertModule("test/fixtures/src/main.js",createModuleUrl(`import A, { a, b, DModule, e } from '${resolveImportSpecifier("test/fixtures/src/a.js")}';
 import c from '${resolveImportSpecifier("test/fixtures/src/c-default.js")}';
 
-console.log('hi there', a, other, b, c, DModule);
+console.log('hi there', A, a, b, c, DModule, e);
 `));
 import(resolveImportSpecifier("test/fixtures/src/main.js"));

--- a/test/fixtures/bundle.js
+++ b/test/fixtures/bundle.js
@@ -1,7 +1,25 @@
 import { insertModule, createModuleUrl, resolveImportSpecifier } from "/bloom.js";
-insertModule("test/fixtures/src/a.js",createModuleUrl(`export const a = 'a value';
-export const other = 'other value';`));
-insertModule("test/fixtures/src/main.js",createModuleUrl(`import { a, other } from '${resolveImportSpecifier("test/fixtures/src/a.js")}';
+insertModule("test/fixtures/src/b.js",createModuleUrl(`const b = 're-export';
 
-console.log('hi there', a, other);`));
+export { b };
+`));
+insertModule("test/fixtures/src/d.js",createModuleUrl(`const d = 're-export';
+
+export default d;
+`));
+insertModule("test/fixtures/src/a.js",createModuleUrl(`export const a = 'a value';
+export const other = 'other value';
+
+export { b } from './b.js';
+export { default as DModule } from './d.js';
+`));
+insertModule("test/fixtures/src/c-default.js",createModuleUrl(`const c = 'default export';
+
+export default c;
+`));
+insertModule("test/fixtures/src/main.js",createModuleUrl(`import { a, b, DModule, other } from '${resolveImportSpecifier("test/fixtures/src/a.js")}';
+import c from '${resolveImportSpecifier("test/fixtures/src/c-default.js")}';
+
+console.log('hi there', a, other, b, c, DModule);
+`));
 import(resolveImportSpecifier("test/fixtures/src/main.js"));

--- a/test/fixtures/bundle.js
+++ b/test/fixtures/bundle.js
@@ -17,10 +17,10 @@ export { A };
 `));
 insertModule("test/fixtures/src/a.js",createModuleUrl(`export const a = 'a value';
 
-export { b } from './b.js';
-export * from './e.js';
-export { default as DModule } from './d.js';
-export { A as default } from './a-default.js';
+export { b } from '${resolveImportSpecifier("test/fixtures/src/b.js")}';
+export * from '${resolveImportSpecifier("test/fixtures/src/e.js")}';
+export { default as DModule } from '${resolveImportSpecifier("test/fixtures/src/d.js")}';
+export { A as default } from '${resolveImportSpecifier("test/fixtures/src/a-default.js")}';
 `));
 insertModule("test/fixtures/src/c-default.js",createModuleUrl(`const c = 'default export';
 

--- a/test/fixtures/src/a-default.js
+++ b/test/fixtures/src/a-default.js
@@ -1,0 +1,3 @@
+const A = () => {};
+
+export { A };

--- a/test/fixtures/src/a.js
+++ b/test/fixtures/src/a.js
@@ -1,2 +1,5 @@
 export const a = 'a value';
 export const other = 'other value';
+
+export { b } from './b.js';
+export { default as DModule } from './d.js';

--- a/test/fixtures/src/a.js
+++ b/test/fixtures/src/a.js
@@ -1,5 +1,6 @@
 export const a = 'a value';
-export const other = 'other value';
 
 export { b } from './b.js';
+export * from './e.js';
 export { default as DModule } from './d.js';
+export { A as default } from './a-default.js';

--- a/test/fixtures/src/b.js
+++ b/test/fixtures/src/b.js
@@ -1,0 +1,3 @@
+const b = 're-export';
+
+export { b };

--- a/test/fixtures/src/c-default.js
+++ b/test/fixtures/src/c-default.js
@@ -1,0 +1,3 @@
+const c = 'default export';
+
+export default c;

--- a/test/fixtures/src/d.js
+++ b/test/fixtures/src/d.js
@@ -1,0 +1,3 @@
+const d = 're-export';
+
+export default d;

--- a/test/fixtures/src/d.js
+++ b/test/fixtures/src/d.js
@@ -1,3 +1,3 @@
-const d = 're-export';
+const d = 're-export default';
 
 export default d;

--- a/test/fixtures/src/e.js
+++ b/test/fixtures/src/e.js
@@ -1,0 +1,3 @@
+const e = 're-export e-aggregate';
+
+export { e };

--- a/test/fixtures/src/main.js
+++ b/test/fixtures/src/main.js
@@ -1,4 +1,4 @@
-import { a, b, DModule, other } from './a.js';
+import A, { a, b, DModule, e } from './a.js';
 import c from './c-default.js';
 
-console.log('hi there', a, other, b, c, DModule);
+console.log('hi there', A, a, b, c, DModule, e);

--- a/test/fixtures/src/main.js
+++ b/test/fixtures/src/main.js
@@ -1,3 +1,4 @@
-import { a, other } from './a.js';
+import { a, b, DModule, other } from './a.js';
+import c from './c-default.js';
 
-console.log('hi there', a, other);
+console.log('hi there', a, other, b, c, DModule);


### PR DESCRIPTION
This PR starts to add handling export statements to ensure that they are included in the main bundle.

The strategy here is to get things to work (copy paste or simple imperative logic) and refactor later.  

- [x] re-exports `export { default as d } from './d.js`
- [x] multiple import statements
- [x] Do not register export named list `export { d }` for bundling
- [x] aggregating modules `export * from ...`
- [x] `export { name as default }`
- [x] `import A, { ... } from '...'`

TODO: 
~- [ ]~ register re-export default exports and ensure it is bundled.  I don't think this is possible.  e.g. 

```
// a.js
export default from './b';
```
- [ ] `export { default } from ...`
- [ ] Many more