### PR TITLE
Lexer and Parser enhancement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
-strum_macros = "0.20.1"
+logos = "0.11.4"
 relative-path = "1.3.2"

--- a/src/bundler.rs
+++ b/src/bundler.rs
@@ -1,4 +1,4 @@
-use super::lexer;
+use super::parser;
 use std::collections::HashMap;
 use std::rc::Rc;
 use relative_path::{RelativePath, RelativePathBuf};
@@ -8,65 +8,65 @@ pub struct JavascriptBundle {
     pub content: String,
 }
 
-pub fn bundle(entry_module: String, module_map: HashMap<String, lexer::JavascriptModule>) -> JavascriptBundle {
-  let mut content = String::new();
-  content.push_str("import { insertModule, createModuleUrl, resolveImportSpecifier } from \"/bloom.js\";\n");
+pub fn bundle(entry_module: String, module_map: HashMap<String, parser::JavascriptModule>) -> JavascriptBundle {
+    let mut content = String::new();
+    content.push_str("import { insertModule, createModuleUrl, resolveImportSpecifier } from \"/bloom.js\";\n");
 
-  traverse_module(&entry_module, &mut content, Rc::new(module_map));
+    traverse_module(&entry_module, &mut content, Rc::new(module_map));
 
-  content.push_str("import(resolveImportSpecifier(\"");
-  content.push_str(entry_module.as_str());
-  content.push_str("\"));");
+    content.push_str("import(resolveImportSpecifier(\"");
+    content.push_str(entry_module.as_str());
+    content.push_str("\"));");
 
-  println!("{}", content);
+    println!("{}", content);
 
-  JavascriptBundle {
-    content
-  }
+    JavascriptBundle {
+        content
+    }
 }
 
-fn traverse_module(file_path: &String, content: &mut String, module_map: Rc<HashMap<String, lexer::JavascriptModule>>) {
-  let full_path = RelativePath::new(file_path).to_path(current_dir().unwrap().as_path());
-  let module = module_map.get(full_path.to_str().unwrap()).expect(format!("File not found in module_map {}", full_path.to_str().unwrap()).as_str());
+fn traverse_module(file_path: &String, content: &mut String, module_map: Rc<HashMap<String, parser::JavascriptModule>>) {
+    let full_path = RelativePath::new(file_path).to_path(current_dir().unwrap().as_path());
+    let module = module_map.get(full_path.to_str().unwrap()).expect(format!("File not found in module_map {}", full_path.to_str().unwrap()).as_str());
 
-  let mut parent_path_buf = RelativePathBuf::from(file_path.as_str());
-  parent_path_buf.pop();
+    let mut parent_path_buf = RelativePathBuf::from(file_path.as_str());
+    parent_path_buf.pop();
 
-  for import in module.imports.iter() {
-    let mod_path = parent_path_buf.join_normalized(RelativePath::new(&import.specifier));
-    traverse_module(&mod_path.to_string(), content, Rc::clone(&module_map));
-  }
+    for import in module.imports.iter() {
+        let mod_path = parent_path_buf.join_normalized(RelativePath::new(&import.specifier));
+        traverse_module(&mod_path.to_string(), content, Rc::clone(&module_map));
+    }
 
-  for export in module.exports.iter() {
-    let mod_path = parent_path_buf.join_normalized(RelativePath::new(&export.specifier));
-    traverse_module(&mod_path.to_string(), content, Rc::clone(&module_map));
-  }
+    for export in module.exports.iter() {
+        let mod_path = parent_path_buf.join_normalized(RelativePath::new(&export.specifier));
+        traverse_module(&mod_path.to_string(), content, Rc::clone(&module_map));
+    }
 
-  content.push_str("insertModule(\"");
-  content.push_str(file_path.as_str());
-  content.push_str("\",createModuleUrl(`");
+    content.push_str("insertModule(\"");
+    content.push_str(file_path.as_str());
+    content.push_str("\",createModuleUrl(`");
 
-  let mut last_index: usize = 0;
-  for import in module.imports.iter() {
-    let mod_path = parent_path_buf.join_normalized(RelativePath::new(&import.specifier));
-    content.push_str(module.raw_source.get(last_index..import.specifier_start).unwrap());
-    content.push_str("${resolveImportSpecifier(\"");
-    content.push_str(&mod_path.to_string().as_str());
-    content.push_str("\")}");
-    last_index = import.specifier_end + 1;
-  }
+    let mut last_index: usize = 0;
+    for import in module.imports.iter() {
+        content.push_str(module.raw_source.get(last_index..=import.specifier_start).unwrap());
+        content.push_str("${resolveImportSpecifier(\"");
+        let mod_path = parent_path_buf.join_normalized(RelativePath::new(&import.specifier));
+        content.push_str(&mod_path.to_string().as_str());
+        content.push_str("\")}");
+        last_index = import.specifier_end - 1; // take into account ending specifier quote or dbl quote
+    }
 
-  for export in module.exports.iter() {
-    let mod_path = parent_path_buf.join_normalized(RelativePath::new(&export.specifier));
-    content.push_str(module.raw_source.get(last_index..export.specifier_start).unwrap());
-    content.push_str("${resolveImportSpecifier(\"");
-    content.push_str(&mod_path.to_string().as_str());
-    content.push_str("\")}");
-    last_index = export.specifier_end + 1;
-  }
+    for export in module.exports.iter() {
+        let mod_path = parent_path_buf.join_normalized(RelativePath::new(&export.specifier));
+        content.push_str(module.raw_source.get(last_index..=export.specifier_start).unwrap());
+        content.push_str("${resolveImportSpecifier(\"");
+        content.push_str(&mod_path.to_string().as_str());
+        content.push_str("\")}");
+        last_index = export.specifier_end - 1; // take into account ending specifier quote or dbl quote
+    }
 
-  if last_index < module.raw_source.len() {
-    content.push_str(module.raw_source.get(last_index..module.raw_source.len()).unwrap());
-  }
-  content.push_str("`));\n");
+    if last_index < module.raw_source.len() {
+        content.push_str(module.raw_source.get(last_index..module.raw_source.len()).unwrap());
+    }
+    content.push_str("`));\n");
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,658 +1,75 @@
-use std::convert::AsRef;
-use strum_macros::AsRefStr;
-
-#[derive(Debug)]
-pub struct JavascriptModule {
-  pub imports: Vec<JavascriptImport>,
-  pub exports: Vec<JavascriptExport>,
-  pub raw_source: String,
-}
+use logos::Logos;
 
 #[derive(Debug, PartialEq)]
-enum ImportToken {
-  Variables, // represents a block of possible NamedImports or DefaultImports
-  From,
-  Specifier,
-  DefaultImport,
-  NamedImport,
-  NextNamedImport,
-  StatementEnd,
+pub(crate) struct Token<'a> {
+    pub kind: TokenKind,
+    pub text: &'a str,
 }
 
-#[derive(Debug)]
-enum ExportToken {
-  Variables,
-  From,
-  Specifier,
-  NamedExport,
-  NextNamedExport,
-  StatementEnd,
+pub(crate) struct JavascriptLexer<'a> {
+    inner: logos::Lexer<'a, TokenKind>,
 }
 
-#[derive(Debug)]
-struct PendingJavascriptImport {
-  import: JavascriptImport,
-  expected_token: ImportToken,
-  token_start: Option<usize>,
-  str_char: Option<char>,
+impl<'a> JavascriptLexer<'a> {
+    pub(crate) fn new(source: &'a str) -> Self {
+        Self {
+            inner: TokenKind::lexer(source)
+        }
+    }
 }
 
-// TODO: Backtracking to ensure there is a specifier
-#[derive(Debug)]
-struct PendingJavascriptExport {
-  export: JavascriptExport,
-  expected_token: ExportToken,
-  token_start: Option<usize>,
-  str_char: Option<char>,
+impl<'a> Iterator for JavascriptLexer<'a> {
+    type Item = Token<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let kind = self.inner.next()?;
+        let text = self.inner.slice();
+
+        Some(Self::Item { kind, text })
+    }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct JavascriptImport {
-  pub default_name: Option<String>,
-  pub default_import: Option<DefaultImport>,
-  pub named_imports: Vec<NamedImport>,
-  pub specifier: String,
-  pub specifier_start: usize,
-  pub specifier_end: usize,
-}
+#[derive(Logos, Debug, Clone, PartialEq)]
+pub(crate) enum TokenKind {
+    #[regex("[ \n]+")]
+    Whitespace,
 
-#[derive(Debug, PartialEq)]
-pub struct DefaultImport {
-  variable_name: String,
-  binding_name: String
-}
+    #[token("import")]
+    Import,
 
-#[derive(Debug, PartialEq)]
-pub struct NamedImport {
-  variable_name: String,
-  binding_name: String
-}
+    #[token("export")]
+    Export,
 
-#[derive(Debug)]
-pub struct JavascriptExport {
-  pub default_name: Option<String>,
-  pub named_exports: Vec<NamedExport>,
-  pub specifier: String,
-  pub specifier_start: usize,
-  pub specifier_end: usize,
-}
+    #[token("default")]
+    Default,
 
-#[derive(Debug)]
-pub struct NamedExport {
-  variable_name: String,
-  binding_name: String // TODO: what is the difference?
-}
+    #[token("from")]
+    From,
 
-pub struct JavascriptLexer {
-  source: String,
-  current_index: usize,
-  current_char: char,
-  indices_to_skip: usize,
-  handler_stack: Vec<Handler>,
-  current_handler: Handler,
-  pending_import: Option<PendingJavascriptImport>,
-  pending_export: Option<PendingJavascriptExport>,
-}
+    #[token("as")]
+    As,
 
-#[derive(Clone, Copy, AsRefStr, Debug)]
-enum Handler {
-  Normal,
-  Import,
-  Export,
-}
+    #[token(",")]
+    Comma,
 
-#[derive(Clone, Copy)]
-enum ImportTokens {
-  Variables,
-  From,
-  Specifier
-}
+    #[token(";")]
+    Semicolon,
 
-impl JavascriptLexer {
-  pub fn new(source: String) -> JavascriptLexer {
-    JavascriptLexer {
-      source,
-      current_index: 0,
-      current_char: ' ',
-      indices_to_skip: 0,
-      handler_stack: Vec::new(),
-      current_handler: Handler::Normal,
-      pending_import: None,
-      pending_export: None
-    }
-  }
+    #[token("*")]
+    Star,
 
-  pub fn parse_module(&mut self) -> JavascriptModule {
-    let mut js_module = JavascriptModule {
-      imports: Vec::new(),
-      exports: Vec::new(),
-      raw_source: self.source.clone(),
-    };
+    #[token("}")]
+    RBrace,
 
-    self.source = self.source.to_string();
-    self.current_char = ' ';
-    self.current_index = 0;
-    self.indices_to_skip = 0;
-    self.handler_stack = Vec::new();
-    self.handler_stack.push(Handler::Normal);
+    #[token("{")]
+    LBrace,
 
-    let source = self.source.clone();
+    #[regex("['\"]./[a-zA-Z0-9_-]+.js['\"]")] //TODO improve
+    Specifier,
 
-    for (i, c) in source.char_indices() {
-      if self.indices_to_skip > 0 {
-        self.indices_to_skip = self.indices_to_skip - 1;
-        continue
-      }
+    #[regex("[A-Za-z][A-Za-z0-9]*")]
+    Ident,
 
-      self.current_char = c;
-      self.current_index = i;
-
-      self.current_handler = self.handler_stack.pop().expect(format!("JavascriptLexer died - no handler specified at index {}. Last handler was {}", i, self.current_handler.as_ref()).as_str());
-
-      match self.current_handler {
-        Handler::Normal => self.handle_normal(&mut js_module),
-        Handler::Import => self.handle_import(&mut js_module),
-        Handler::Export => self.handle_export(&mut js_module),
-      }
-    }
-
-    js_module
-  }
-
-  fn keep_using_handler(&mut self) {
-    self.handler_stack.push(self.current_handler);
-  }
-
-  fn queue_handler(&mut self, handler: Handler) {
-    self.handler_stack.push(handler);
-  }
-
-  fn handle_normal(&mut self, _js_module: &mut JavascriptModule) {
-    match self.current_char {
-      'i' => {
-        match self.source.get(self.current_index..self.current_index + 6).unwrap_or("") {
-          "import" => {
-            self.queue_handler(Handler::Import);
-            self.indices_to_skip = 5;
-            self.pending_import = Some(PendingJavascriptImport {
-              expected_token: ImportToken::Variables,
-              import: JavascriptImport {
-                default_name: None,
-                named_imports: Vec::new(),
-                default_import: None,
-                specifier: String::new(),
-                specifier_start: 0,
-                specifier_end: 0,
-              },
-              token_start: None,
-              str_char: None,
-            });
-          },
-          _ => {
-            self.keep_using_handler();
-          }
-        }
-      },
-      'e' => {
-        match self.source.get(self.current_index..self.current_index + 6).unwrap_or("") {
-          "export" => {
-            self.queue_handler(Handler::Export);
-            self.indices_to_skip = 5;
-            self.pending_export = Some(PendingJavascriptExport {
-              expected_token: ExportToken::Variables,
-              export: JavascriptExport {
-                default_name: None,
-                named_exports: Vec::new(),
-                specifier: String::new(),
-                specifier_start: 0,
-                specifier_end: 0,
-              },
-              token_start: None,
-              str_char: None,
-            });
-          },
-          _ => {
-            self.keep_using_handler();
-          }
-        }
-      },
-      _ => {
-        self.keep_using_handler();
-      }
-    }
-  }
-
-  fn handle_import(&mut self, js_module: &mut JavascriptModule) {
-    let mut pending_import = self.pending_import.as_mut().unwrap();
-
-    match pending_import.expected_token {
-      ImportToken::Variables => {
-        match self.current_char {
-          '{' => {
-            pending_import.expected_token = ImportToken::NamedImport;
-          },
-          '\u{0041}'..='\u{2FA1D}' => {
-            pending_import.expected_token = ImportToken::DefaultImport;
-            pending_import.token_start = Some(self.current_index);
-          }
-          _ => {
-              // is_whitespace
-          }
-        }
-
-        self.keep_using_handler();
-      },
-      ImportToken::DefaultImport => {
-        match self.current_char {
-          '\u{0030}'..='\u{E01EF}' => {}, // still parsing the DefaultImport
-          _ => {
-            let identifier = String::from(self.source.get(pending_import.token_start.unwrap()..self.current_index).unwrap());
-            let default_import = DefaultImport {
-              variable_name: identifier.clone(),
-              binding_name: identifier,
-            };
-            pending_import.import.default_import = Some(default_import);
-            let next_token;
-            match self.current_char {
-              ',' => {
-                // import A, { ... } from
-                // TODO: None?
-                pending_import.token_start = None;
-                next_token = ImportToken::Variables;
-              },
-              _ => {
-                // whitespace
-                next_token = ImportToken::From;
-                pending_import.token_start = None;
-              }
-            }
-            pending_import.expected_token = next_token;
-          }
-        }
-        self.keep_using_handler();
-      },
-      ImportToken::NamedImport => {
-        if pending_import.token_start.is_none() {
-          match self.current_char {
-            c if c.is_whitespace() => {},
-            '\u{0041}'..='\u{2FA1D}' => {
-              pending_import.token_start = Some(self.current_index);
-            },
-            _ => {
-              panic!(format!("Invalid character '{}' at index {} - expected identifier start", self.current_char, self.current_index));
-            }
-          }
-        } else {
-          match self.current_char {
-            '\u{0030}'..='\u{E01EF}' => {
-               // still parsing the NamedImport
-            },
-            _ => {
-              let identifier = String::from(self.source.get(pending_import.token_start.unwrap()..self.current_index).unwrap());
-              let named_import = NamedImport {
-                variable_name: identifier.clone(),
-                binding_name: identifier,
-              };
-              pending_import.import.named_imports.push(named_import);
-              let next_token;
-              match self.current_char {
-                '}' => {
-                  next_token = ImportToken::From;
-                },
-                ',' => {
-                  next_token = ImportToken::NamedImport;
-                },
-                _ => {
-                  // whitespace
-                  next_token = ImportToken::NextNamedImport;
-                }
-              }
-              pending_import.expected_token = next_token;
-              pending_import.token_start = None;
-            }
-          }
-        }
-        self.keep_using_handler();
-      },
-      ImportToken::NextNamedImport => {
-        match self.current_char {
-          '}' => {
-            pending_import.expected_token = ImportToken::From;
-          },
-          ',' => {
-            pending_import.expected_token = ImportToken::NamedImport;
-          },
-          c if c.is_whitespace() => {},
-          _ => {
-            panic!(format!("Invalid character '{}' at index {} - expected ',' or '}}'", self.current_char, self.current_index));
-          }
-        }
-        self.keep_using_handler();
-      },
-      ImportToken::From => {
-        match self.current_char {
-          c if c.is_whitespace() => {},
-          'f' => {
-            match self.source.get(self.current_index..self.current_index+4).unwrap_or("f") {
-              "from" => {
-                self.indices_to_skip = 3;
-                pending_import.expected_token = ImportToken::Specifier;
-              },
-              _ => {
-                panic!(format!("Invalid character '{}' at index {} - expected keyword 'from'", self.current_char, self.current_index));
-              }
-            }
-          },
-          _ => {
-            panic!(format!("Invalid character '{}' at index {} - expected keyword 'from'", self.current_char, self.current_index));
-          }
-        }
-        self.keep_using_handler();
-      },
-      ImportToken::Specifier => {
-        if pending_import.token_start.is_none() {
-          match self.current_char {
-            c if c.is_whitespace() => {},
-            '\'' | '"' => {
-              pending_import.token_start = Some(self.current_index + 1);
-              pending_import.str_char = Some(self.current_char);
-              pending_import.expected_token = ImportToken::Specifier;
-              pending_import.import.specifier_start = self.current_index + 1;
-            },
-            _ => {
-              panic!(format!("Invalid character '{}' at index {} - expected string start ' or \"", self.current_char, self.current_index));
-            }
-          }
-        } else {
-          match self.current_char {
-            c if c == pending_import.str_char.unwrap() => {
-              pending_import.import.specifier = String::from(self.source.get(pending_import.token_start.unwrap()..self.current_index).unwrap());
-              pending_import.expected_token = ImportToken::StatementEnd;
-              pending_import.import.specifier_end = self.current_index - 1;
-            },
-            _ => {}
-          }
-        }
-        self.keep_using_handler();
-      },
-      ImportToken::StatementEnd => {
-        match self.current_char {
-          c if c == ' ' => {},
-          ';' | '\n' | '\r' => {
-            js_module.imports.push(self.pending_import.take().unwrap().import);
-            self.queue_handler(Handler::Normal);
-          },
-          _ => {
-            panic!(format!("Invalid character '{}' at index {} - expected statement end", self.current_char, self.current_index));
-          }
-        }
-      },
-    }
-  }
-
-  fn handle_export(&mut self, js_module: &mut JavascriptModule) {
-    let mut pending_export = self.pending_export.as_mut().unwrap();
-
-    match pending_export.expected_token {
-      ExportToken::Variables => {
-        match self.current_char {
-          '{' => {
-            pending_export.expected_token = ExportToken::NamedExport;
-          },
-          '*' => {
-            pending_export.expected_token = ExportToken::From;
-          },
-          _ => {}
-        }
-
-        self.keep_using_handler();
-      },
-      ExportToken::NamedExport => {
-        if pending_export.token_start.is_none() {
-          match self.current_char {
-            c if c.is_whitespace() => {},
-            '\u{0041}'..='\u{2FA1D}' => {
-              pending_export.token_start = Some(self.current_index);
-            },
-            _ => {
-              panic!(format!("Invalid character '{}' at index {} - expected identifier start", self.current_char, self.current_index));
-            }
-          }
-        } else {
-          match self.current_char {
-            '\u{0030}'..='\u{E01EF}' => {},
-            _ => {
-              let identifier = String::from(self.source.get(pending_export.token_start.unwrap()..self.current_index).unwrap());
-              if identifier == "default" {
-                  // TODO: this can be improved.  "default as" w/ backtracking?
-                  // reset since next identifier will alias default "export { default as ... }"
-                  pending_export.token_start = None;
-                  pending_export.expected_token = ExportToken::NextNamedExport;
-              } else {
-                  let named_export = NamedExport {
-                    variable_name: identifier.clone(),
-                    binding_name: identifier,
-                  };
-                  pending_export.export.named_exports.push(named_export);
-                  let next_token;
-                  match self.current_char {
-                    '}' => {
-                      next_token = ExportToken::From;
-                    },
-                    ',' => {
-                      next_token = ExportToken::NamedExport;
-                    },
-                    _ => {
-                      next_token = ExportToken::NextNamedExport;
-                    }
-                  }
-                  pending_export.expected_token = next_token;
-                  pending_export.token_start = None;
-              }
-            }
-          }
-        }
-        self.keep_using_handler();
-      },
-      ExportToken::NextNamedExport => {
-        match self.current_char {
-          '}' => {
-            pending_export.expected_token = ExportToken::From;
-          },
-          ',' => {
-            pending_export.expected_token = ExportToken::NamedExport;
-          },
-          'a' => {
-            // re-export: `export { default as b } from './b';`
-            self.indices_to_skip = 1;
-            pending_export.expected_token = ExportToken::NamedExport;
-          },
-          _ => {
-            panic!(format!("Invalid character '{}' at index {} - expected ',' or keyword 'as' or '}}'", self.current_char, self.current_index));
-          }
-        }
-        self.keep_using_handler();
-      },
-      ExportToken::From => {
-        match self.current_char {
-          c if c.is_whitespace() => {},
-          'f' => {
-            match self.source.get(self.current_index..self.current_index+4).unwrap_or("f") {
-              "from" => {
-                self.indices_to_skip = 3;
-                pending_export.expected_token = ExportToken::Specifier;
-              },
-              _ => {
-                panic!(format!("Invalid character '{}' at index {} - expected keyword 'from'", self.current_char, self.current_index));
-              }
-            }
-          },
-          ';' => {
-            // export { b };
-            // This ended up not being an export with a specifier, so do not record as
-            // pending_export
-            self.pending_export = None;
-            self.queue_handler(Handler::Normal);
-            return;
-          }
-          _ => {
-            panic!(format!("Invalid character '{}' at index {} - expected keyword 'from' or statement end ';'", self.current_char, self.current_index));
-          }
-        }
-        self.keep_using_handler();
-      },
-      ExportToken::Specifier => {
-        if pending_export.token_start.is_none() {
-          match self.current_char {
-            c if c.is_whitespace() => {},
-            '\'' | '"' => {
-              pending_export.token_start = Some(self.current_index + 1);
-              pending_export.str_char = Some(self.current_char);
-              pending_export.expected_token = ExportToken::Specifier;
-              pending_export.export.specifier_start = self.current_index + 1;
-            },
-            _ => {
-              panic!(format!("Invalid character '{}' at index {} - expected string start ' or \"", self.current_char, self.current_index));
-            }
-          }
-        } else {
-          match self.current_char {
-            c if c == pending_export.str_char.unwrap() => {
-              pending_export.export.specifier = String::from(self.source.get(pending_export.token_start.unwrap()..self.current_index).unwrap());
-              pending_export.expected_token = ExportToken::StatementEnd;
-              pending_export.export.specifier_end = self.current_index - 1;
-            },
-            _ => {}
-          }
-        }
-        self.keep_using_handler();
-      },
-      ExportToken::StatementEnd => {
-        match self.current_char {
-          c if c == ' ' => {},
-          ';' | '\n' | '\r' => {
-            js_module.exports.push(self.pending_export.take().unwrap().export);
-            self.queue_handler(Handler::Normal);
-          },
-          _ => {
-            panic!(format!("Invalid character '{}' at index {} - expected statement end", self.current_char, self.current_index));
-          }
-        }
-      },
-    }
-  }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_single_import() {
-        let source = String::from("
-import A from './a.js';
-");
-        let module = JavascriptLexer::new(source.clone()).parse_module();
-        assert_eq!(module.imports.len(), 1);
-        assert_eq!(module.exports.len(), 0);
-        assert_eq!(module.raw_source, source);
-    }
-    #[test]
-    fn parses_multiple_imports() {
-        let source = String::from("
-import A from './a.js';
-import c from './c.js';
-");
-        let module = JavascriptLexer::new(source.clone()).parse_module();
-        assert_eq!(module.imports.len(), 2);
-        assert_eq!(module.exports.len(), 0);
-        assert_eq!(module.raw_source, source);
-    }
-
-    #[test]
-    fn does_not_parse_default_export() {
-        let source = String::from("
-class C {}
-export default C;
-");
-        let module = JavascriptLexer::new(source.clone()).parse_module();
-        assert_eq!(module.imports.len(), 0);
-        assert_eq!(module.exports.len(), 0);
-        assert_eq!(module.raw_source, source);
-    }
-
-    #[test]
-    fn does_not_parse_named_export() {
-        let source = String::from("
-const e = 'e';
-
-export { e };
-");
-        let module = JavascriptLexer::new(source.clone()).parse_module();
-        assert_eq!(module.imports.len(), 0);
-        assert_eq!(module.exports.len(), 0);
-        assert_eq!(module.raw_source, source);
-    }
-
-    #[test]
-    fn parses_named_export() {
-        let source = String::from("
-export { b } from './b.js';
-");
-        let module = JavascriptLexer::new(source.clone()).parse_module();
-        assert_eq!(module.imports.len(), 0);
-        assert_eq!(module.exports.len(), 1);
-        assert_eq!(module.raw_source, source);
-    }
-
-    #[test]
-    fn parses_default_export() {
-        let source = String::from("
-export { b as default } from './b.js';
-");
-        let module = JavascriptLexer::new(source.clone()).parse_module();
-        assert_eq!(module.imports.len(), 0);
-        assert_eq!(module.exports.len(), 1);
-        assert_eq!(module.raw_source, source);
-    }
-
-    #[test]
-    fn parses_splat_export() {
-        let source = String::from("
-export * from './b.js';
-");
-        let module = JavascriptLexer::new(source.clone()).parse_module();
-        assert_eq!(module.imports.len(), 0);
-        assert_eq!(module.exports.len(), 1);
-        assert_eq!(module.raw_source, source);
-    }
-
-    #[test]
-    fn import_export_test() {
-        let source = String::from("
-import { AImport } from './a.js';
-import cDefault from './c.js';
-export * from './d.js';
-export { b as default } from './b.js';
-");
-        let module = JavascriptLexer::new(source.clone()).parse_module();
-        assert_eq!(module.imports.len(), 2);
-        assert_eq!(module.imports[0].specifier, "./a.js");
-        assert_eq!(module.imports[0].named_imports.len(), 1);
-        assert_eq!(module.imports[0].named_imports, vec![NamedImport {
-            variable_name: String::from("AImport"),
-            binding_name: String::from("AImport")
-        }]);
-        assert_eq!(module.imports[0].default_import, None);
-        assert_eq!(module.imports[1].specifier, "./c.js");
-        assert_eq!(module.imports[1].named_imports.len(), 0);
-        assert_eq!(module.imports[1].default_import, Some(DefaultImport {
-            variable_name: String::from("cDefault"),
-            binding_name: String::from("cDefault")
-        }));
-        assert_eq!(module.exports.len(), 2);
-        assert_eq!(module.exports[0].specifier, "./d.js");
-        assert_eq!(module.exports[1].specifier, "./b.js");
-        assert_eq!(module.raw_source, source);
-    }
+    #[error]
+    Error,
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -13,7 +13,7 @@ pub(crate) struct JavascriptLexer<'a> {
 impl<'a> JavascriptLexer<'a> {
     pub(crate) fn new(source: &'a str) -> Self {
         Self {
-            inner: TokenKind::lexer(source)
+            inner: TokenKind::lexer(source),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,13 @@
 use std::fs;
 pub mod lexer;
+pub mod parser;
 pub mod bundler;
 use std::collections::HashMap;
 use relative_path::{RelativePath, RelativePathBuf};
 use std::env::current_dir;
 
 fn main() {
-    let mut module_map: HashMap<String, lexer::JavascriptModule> = HashMap::new();
+    let mut module_map: HashMap<String, parser::JavascriptModule> = HashMap::new();
     let entry_file = String::from("test/fixtures/src/main.js");
     module_map = traverse_file(entry_file.clone(), module_map);
 
@@ -16,9 +17,12 @@ fn main() {
     println!("bundle.js written");
 }
 
-fn traverse_file(file_path: String, mut module_map: HashMap<String, lexer::JavascriptModule>) -> HashMap<String, lexer::JavascriptModule> {
+fn traverse_file(file_path: String, mut module_map: HashMap<String, parser::JavascriptModule>) -> HashMap<String, parser::JavascriptModule> {
     let source = fs::read_to_string(file_path.clone()).expect(format!("Unable to read {}", file_path.clone()).as_str());
-    let module: lexer::JavascriptModule = lexer::JavascriptLexer::new(source).parse_module();
+
+    let tokens: Vec<_> = lexer::JavascriptLexer::new(&source).collect();
+    let parser = parser::Parser::new(&tokens);
+    let module = parser.parse_module(source.clone());
 
     for import in module.imports.iter() {
         let mut parent_path_buf = RelativePathBuf::from(file_path.as_str());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use std::fs;
+pub mod bundler;
 pub mod lexer;
 pub mod parser;
-pub mod bundler;
-use std::collections::HashMap;
 use relative_path::{RelativePath, RelativePathBuf};
+use std::collections::HashMap;
 use std::env::current_dir;
 
 fn main() {
@@ -17,8 +17,12 @@ fn main() {
     println!("bundle.js written");
 }
 
-fn traverse_file(file_path: String, mut module_map: HashMap<String, parser::JavascriptModule>) -> HashMap<String, parser::JavascriptModule> {
-    let source = fs::read_to_string(file_path.clone()).expect(format!("Unable to read {}", file_path.clone()).as_str());
+fn traverse_file(
+    file_path: String,
+    mut module_map: HashMap<String, parser::JavascriptModule>,
+) -> HashMap<String, parser::JavascriptModule> {
+    let source = fs::read_to_string(file_path.clone())
+        .expect(format!("Unable to read {}", file_path.clone()).as_str());
 
     let tokens: Vec<_> = lexer::JavascriptLexer::new(&source).collect();
     let parser = parser::Parser::new(&tokens);
@@ -39,7 +43,11 @@ fn traverse_file(file_path: String, mut module_map: HashMap<String, parser::Java
         module_map = traverse_file(mod_path.to_string(), module_map);
     }
 
-    let full_path = RelativePath::new(file_path.as_str()).to_path(current_dir().unwrap().as_path()).to_str().unwrap().to_string();
+    let full_path = RelativePath::new(file_path.as_str())
+        .to_path(current_dir().unwrap().as_path())
+        .to_str()
+        .unwrap()
+        .to_string();
 
     module_map.insert(full_path, module);
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,658 @@
+use crate::lexer::{Token, TokenKind};
+
+#[derive(Debug)]
+pub struct JavascriptModule {
+    pub imports: Vec<JavascriptImport>,
+    pub exports: Vec<JavascriptExport>,
+    pub raw_source: String
+}
+
+#[derive(Debug, PartialEq)]
+pub struct JavascriptImport {
+    default_import: Option<DefaultImport>,
+    named_imports: Vec<NamedImport>,
+    pub specifier: String,
+    pub specifier_start: usize,
+    pub specifier_end: usize,
+}
+
+impl JavascriptImport {
+    fn new() -> Self {
+        Self {
+            named_imports: Vec::new(),
+            default_import: None,
+            specifier: String::from(""),
+            specifier_start: 0,
+            specifier_end: 0,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct JavascriptExport {
+    default_export: Option<DefaultExport>,
+    named_exports: Vec<NamedExport>,
+    pub specifier: String,
+    pub specifier_start: usize,
+    pub specifier_end: usize,
+}
+
+impl JavascriptExport {
+    fn new() -> Self {
+        Self {
+            named_exports: Vec::new(),
+            default_export: None,
+            specifier: String::from(""),
+            specifier_start: 0,
+            specifier_end: 0,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PendingImport {
+    import: JavascriptImport,
+}
+
+#[derive(Debug, PartialEq)]
+struct DefaultImport {
+    variable_name: String,
+    binding_name: String,
+}
+
+#[derive(Debug, PartialEq)]
+struct NamedImport<> {
+    variable_name: String,
+    binding_name: String,
+}
+
+#[derive(Debug, PartialEq)]
+enum NextToken {
+  Specifier,
+  DefaultImport,
+  DefaultExport,
+  NamedImport,
+  NamedExport,
+  StatementEnd,
+  Continue,
+}
+
+#[derive(Debug)]
+struct PendingExport {
+    export: JavascriptExport,
+}
+
+#[derive(Debug, PartialEq)]
+struct DefaultExport {
+    variable_name: String,
+    binding_name: String,
+}
+
+#[derive(Debug, PartialEq)]
+struct NamedExport<> {
+    variable_name: String,
+    binding_name: String,
+}
+
+pub(crate) struct Parser<'l, 'a> {
+    tokens: &'l [Token<'a>],
+    pending_import: Option<PendingImport>,
+    pending_export: Option<PendingExport>,
+    next_token: NextToken,
+    cursor: usize
+}
+
+impl<'l, 'a> Parser<'l, 'a> {
+    pub fn new(tokens: &'l [Token<'a>]) -> Self {
+        Self {
+            tokens,
+            pending_import: None,
+            pending_export: None,
+            next_token: NextToken::DefaultImport,
+            cursor: 0,
+        }
+    }
+
+    pub fn parse_module(mut self, raw_source: String) -> JavascriptModule {
+        let mut js_module = JavascriptModule {
+            imports: Vec::new(),
+            exports: Vec::new(),
+            raw_source
+        };
+
+        for Token { kind, text } in self.tokens {
+            match kind {
+                TokenKind::Import => {
+                    self.pending_import = Some(PendingImport {
+                        import: JavascriptImport::new(),
+                    });
+                    self.next_token = NextToken::DefaultImport;
+                },
+                TokenKind::Export => {
+                    self.pending_export = Some(PendingExport {
+                        export: JavascriptExport::new(),
+                    });
+                    self.next_token = NextToken::DefaultExport;
+                },
+                TokenKind::From => {
+                    if self.pending_import_or_export() {
+                        self.next_token = NextToken::Specifier;
+                    }
+                },
+                TokenKind::Ident => {
+                    if self.pending_import.is_some() {
+                        let mut pending_import = self.pending_import.as_mut().unwrap();
+
+                        match self.next_token {
+                            NextToken::NamedImport => {
+                                pending_import.import.named_imports.push(NamedImport {
+                                    variable_name: text.to_string(),
+                                    binding_name: text.to_string()
+                                });
+                            },
+                            NextToken::DefaultImport => {
+                                pending_import.import.default_import = Some(DefaultImport {
+                                    variable_name: text.to_string(),
+                                    binding_name: text.to_string()
+                                });
+                            },
+                            _ => {}
+                        }
+                    } else if self.pending_export.is_some() {
+                        let mut pending_export = self.pending_export.as_mut().unwrap();
+
+                        match self.next_token {
+                            NextToken::NamedExport => {
+                                pending_export.export.named_exports.push(NamedExport {
+                                    variable_name: text.to_string(),
+                                    binding_name: text.to_string()
+                                });
+                            },
+                            NextToken::DefaultExport => {
+                                pending_export.export.default_export = Some(DefaultExport {
+                                    variable_name: text.to_string(),
+                                    binding_name: text.to_string()
+                                });
+                            },
+                            _ => {}
+                        }
+                    }
+                },
+                TokenKind::LBrace | TokenKind::Comma => {
+                    if self.pending_import.is_some() {
+                        self.next_token = NextToken::NamedImport;
+                    } else if self.pending_export.is_some() {
+                        self.next_token = NextToken::NamedExport;
+                    }
+                },
+                TokenKind::RBrace => {
+                    if self.pending_import_or_export() {
+                        self.next_token = NextToken::Specifier;
+                    }
+                },
+                TokenKind::Default => {},
+                TokenKind::As => {},
+                TokenKind::Star => {},
+                TokenKind::Error => {},
+                TokenKind::Specifier => {
+                    if self.pending_import.is_some() {
+                        let mut pending_import = self.pending_import.as_mut().unwrap();
+                        pending_import.import.specifier = text[1..text.len()-1].to_string();
+                        pending_import.import.specifier_start = self.cursor;
+                        pending_import.import.specifier_end = self.cursor + text.len();
+                        self.next_token = NextToken::StatementEnd;
+                    } else if self.pending_export.is_some() {
+                        let mut pending_export = self.pending_export.as_mut().unwrap();
+                        pending_export.export.specifier = text[1..text.len()-1].to_string();
+                        pending_export.export.specifier_start = self.cursor;
+                        pending_export.export.specifier_end = self.cursor + text.len();
+                        self.next_token = NextToken::StatementEnd;
+                    }
+                },
+                TokenKind::Semicolon | TokenKind::Whitespace => {
+                    if self.next_token == NextToken::StatementEnd {
+                        if self.pending_import.is_some() {
+                            js_module.imports.push(self.pending_import.take().unwrap().import);
+                        } else if self.pending_export.is_some() {
+                            js_module.exports.push(self.pending_export.take().unwrap().export);
+                        }
+                        // we are done with this import or export.  Search for more
+                        self.next_token = NextToken::Continue;
+                    }
+                },
+            }
+
+            self.cursor += text.len();
+        }
+
+        js_module
+    }
+
+    fn pending_import_or_export(&self) -> bool {
+        self.pending_import.is_some() || self.pending_export.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::JavascriptLexer;
+
+    #[test]
+    fn parses_single_import() {
+        let source = "
+import A from './a.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 1);
+        assert_eq!(module.exports.len(), 0);
+        assert_eq!(module.imports[0].default_import, Some(
+            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.imports[0].named_imports, []);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+        assert_eq!(module.imports[0].specifier_start, 15);
+        assert_eq!(module.imports[0].specifier_end, 23);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_single_import_with_dbl_quotes() {
+        let source = "
+import A from \"./a.js\";
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 1);
+        assert_eq!(module.exports.len(), 0);
+        assert_eq!(module.imports[0].default_import, Some(
+            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.imports[0].named_imports, []);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+        assert_eq!(module.imports[0].specifier_start, 15);
+        assert_eq!(module.imports[0].specifier_end, 23);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+
+    #[test]
+    fn parses_without_ending_semicolon() {
+        let source = "
+import A from './a.js'
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports[0].default_import, Some(
+            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.imports[0].named_imports, []);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+        assert_eq!(module.imports[0].specifier_start, 15);
+        assert_eq!(module.imports[0].specifier_end, 23);
+    }
+
+    #[test]
+    fn parses_multiple_imports() {
+        let source = "
+import A, { a, b } from './a.js';
+import C, { d, e } from './c.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 2);
+        assert_eq!(module.imports[0].default_import, Some(
+            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.imports[0].named_imports.len(), 2);
+        assert_eq!(module.imports[0].named_imports, [
+            NamedImport { variable_name: String::from("a"), binding_name: String::from("a") },
+            NamedImport { variable_name: String::from("b"), binding_name: String::from("b") }
+        ]);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+        assert_eq!(module.imports[1].named_imports.len(), 2);
+        assert_eq!(module.imports[1].named_imports, [
+            NamedImport { variable_name: String::from("d"), binding_name: String::from("d") },
+            NamedImport { variable_name: String::from("e"), binding_name: String::from("e") }
+        ]);
+    }
+
+    #[test]
+    fn parses_named_import() {
+        let source = "
+import { a } from './a.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 1);
+        assert_eq!(module.imports[0].default_import, None);
+        assert_eq!(module.imports[0].named_imports, [NamedImport { variable_name: String::from("a"), binding_name: String::from("a") }]);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+    }
+
+    #[test]
+    fn parses_multiple_named_imports() {
+        let source = "
+import { a, b } from './a.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 1);
+        assert_eq!(module.imports[0].default_import, None);
+        assert_eq!(module.imports[0].named_imports, [
+            NamedImport { variable_name: String::from("a"), binding_name: String::from("a") },
+            NamedImport { variable_name: String::from("b"), binding_name: String::from("b") }
+        ]);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+    }
+
+    #[test]
+    fn parses_combo_imports() {
+        let source = "
+import A, { a, b } from './a.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 1);
+        assert_eq!(module.imports[0].default_import, Some(
+            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.imports[0].named_imports, [
+            NamedImport { variable_name: String::from("a"), binding_name: String::from("a") },
+            NamedImport { variable_name: String::from("b"), binding_name: String::from("b") }
+        ]);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+    }
+
+    #[test]
+    fn parses_single_export() {
+        let source = "
+export A from './a.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 1);
+        assert_eq!(module.exports[0].default_export, Some(
+            DefaultExport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.exports[0].named_exports, []);
+        assert_eq!(module.exports[0].specifier, "./a.js");
+        assert_eq!(module.exports[0].specifier_start, 15);
+        assert_eq!(module.exports[0].specifier_end, 23);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_named_exports() {
+        let source = "
+export { d, E } from './d.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 1);
+        assert_eq!(module.exports[0].default_export, None);
+        assert_eq!(module.exports[0].named_exports, [
+            NamedExport { variable_name: String::from("d"), binding_name: String::from("d") },
+            NamedExport { variable_name: String::from("E"), binding_name: String::from("E") }
+        ]);
+        assert_eq!(module.exports[0].specifier, "./d.js");
+        assert_eq!(module.exports[0].specifier_start, 22);
+        assert_eq!(module.exports[0].specifier_end, 30);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_as_default_export() {
+        let source = "
+export { b as default } from './b.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 1);
+        assert_eq!(module.exports[0].default_export, None);
+        assert_eq!(module.exports[0].named_exports, [
+            NamedExport { variable_name: String::from("b"), binding_name: String::from("b") },
+        ]);
+        assert_eq!(module.exports[0].specifier, "./b.js");
+        assert_eq!(module.exports[0].specifier_start, 30);
+        assert_eq!(module.exports[0].specifier_end, 38);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_default_as_named_export() {
+        let source = "
+export { default as b } from './b.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 1);
+        assert_eq!(module.exports[0].default_export, None);
+        assert_eq!(module.exports[0].named_exports, [
+            NamedExport { variable_name: String::from("b"), binding_name: String::from("b") },
+        ]);
+        assert_eq!(module.exports[0].specifier, "./b.js");
+        assert_eq!(module.exports[0].specifier_start, 30);
+        assert_eq!(module.exports[0].specifier_end, 38);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_splat_export() {
+        let source = "
+export * from './b.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 1);
+        assert_eq!(module.exports[0].default_export, None);
+        assert_eq!(module.exports[0].named_exports, []);
+        assert_eq!(module.exports[0].specifier, "./b.js");
+        assert_eq!(module.exports[0].specifier_start, 15);
+        assert_eq!(module.exports[0].specifier_end, 23);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_multiple_exports() {
+        let source = "
+export { d, E } from './d.js';
+export A from './a.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 2);
+        assert_eq!(module.exports[0].default_export, None);
+        assert_eq!(module.exports[0].named_exports, [
+            NamedExport { variable_name: String::from("d"), binding_name: String::from("d") },
+            NamedExport { variable_name: String::from("E"), binding_name: String::from("E") }
+        ]);
+        assert_eq!(module.exports[0].specifier, "./d.js");
+        assert_eq!(module.exports[0].specifier_start, 22);
+        assert_eq!(module.exports[0].specifier_end, 30);
+        assert_eq!(module.exports[1].default_export, Some(
+            DefaultExport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.exports[1].named_exports, []);
+        assert_eq!(module.exports[1].specifier, "./a.js");
+        assert_eq!(module.exports[1].specifier_start, 46);
+        assert_eq!(module.exports[1].specifier_end, 54);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_multiple_exports_2() {
+        let source = "
+export { default as DModule } from './d.js';
+export { A as default } from './a-default.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 2);
+        assert_eq!(module.exports[0].default_export, None);
+        assert_eq!(module.exports[0].named_exports, [
+            NamedExport { variable_name: String::from("DModule"), binding_name: String::from("DModule") },
+        ]);
+        assert_eq!(module.exports[0].specifier, "./d.js");
+        assert_eq!(module.exports[0].specifier_start, 36);
+        assert_eq!(module.exports[0].specifier_end, 44);
+        assert_eq!(module.exports[1].default_export, None);
+        assert_eq!(module.exports[1].named_exports, [
+            NamedExport { variable_name: String::from("A"), binding_name: String::from("A") },
+        ]);
+        assert_eq!(module.exports[1].specifier, "./a-default.js");
+        assert_eq!(module.exports[1].specifier_start, 75);
+        assert_eq!(module.exports[1].specifier_end, 91);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn does_not_parse_named_export() {
+        let source = "
+const e = 'e';
+
+export { e };
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 0);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn does_not_parse_default_export() {
+        let source = "
+class C {}
+export default C;
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 0);
+        assert_eq!(module.exports.len(), 0);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_imports_and_exports() {
+        let source = "
+import A from './a.js';
+export E from './e.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 1);
+        assert_eq!(module.exports.len(), 1);
+        assert_eq!(module.imports[0].default_import, Some(
+            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.imports[0].named_imports, []);
+        assert_eq!(module.exports[0].default_export, Some(
+            DefaultExport { variable_name: String::from("E"), binding_name: String::from("E") })
+        );
+        assert_eq!(module.exports[0].named_exports, []);
+        assert_eq!(module.exports[0].specifier, "./e.js");
+        assert_eq!(module.exports[0].specifier_start, 39);
+        assert_eq!(module.exports[0].specifier_end, 47);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn parses_file() {
+        let source = "
+import A from './a.js';
+function() {};
+let z = 'bar';
+export E from './e.js';
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+
+        assert_eq!(module.imports.len(), 1);
+        assert_eq!(module.exports.len(), 1);
+        assert_eq!(module.imports[0].default_import, Some(
+            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.imports[0].named_imports, []);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+        assert_eq!(module.imports[0].specifier_start, 15);
+        assert_eq!(module.imports[0].specifier_end, 23);
+
+        assert_eq!(module.exports[0].default_export, Some(
+            DefaultExport { variable_name: String::from("E"), binding_name: String::from("E") })
+        );
+        assert_eq!(module.exports[0].named_exports, []);
+        assert_eq!(module.exports[0].specifier, "./e.js");
+        assert_eq!(module.exports[0].specifier_start, 69);
+        assert_eq!(module.exports[0].specifier_end, 77);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+    #[test]
+    fn handles_comments() {
+        let source = "
+import A from './a.js'; // test-comment
+/* test-comment */
+import B from './b.js';
+import C from './c.js'; /** test-comment */
+";
+        let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
+        let parser = Parser::new(&tokens);
+        let module = parser.parse_module(source.to_string());
+        assert_eq!(module.imports.len(), 3);
+        assert_eq!(module.exports.len(), 0);
+        assert_eq!(module.imports[0].default_import, Some(
+            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        );
+        assert_eq!(module.imports[0].named_imports, []);
+        assert_eq!(module.imports[0].specifier, "./a.js");
+        assert_eq!(module.imports[0].specifier_start, 15);
+        assert_eq!(module.imports[0].specifier_end, 23);
+        assert_eq!(module.raw_source, source.to_string());
+
+        assert_eq!(module.imports[1].default_import, Some(
+            DefaultImport { variable_name: String::from("B"), binding_name: String::from("B") })
+        );
+        assert_eq!(module.imports[1].named_imports, []);
+        assert_eq!(module.imports[1].specifier, "./b.js");
+        assert_eq!(module.imports[1].specifier_start, 74);
+        assert_eq!(module.imports[1].specifier_end, 82);
+        assert_eq!(module.raw_source, source.to_string());
+
+        assert_eq!(module.imports[2].default_import, Some(
+            DefaultImport { variable_name: String::from("C"), binding_name: String::from("C") })
+        );
+        assert_eq!(module.imports[2].named_imports, []);
+        assert_eq!(module.imports[2].specifier, "./c.js");
+        assert_eq!(module.imports[2].specifier_start, 98);
+        assert_eq!(module.imports[2].specifier_end, 106);
+        assert_eq!(module.raw_source, source.to_string());
+    }
+
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@ use crate::lexer::{Token, TokenKind};
 pub struct JavascriptModule {
     pub imports: Vec<JavascriptImport>,
     pub exports: Vec<JavascriptExport>,
-    pub raw_source: String
+    pub raw_source: String,
 }
 
 #[derive(Debug, PartialEq)]
@@ -61,20 +61,20 @@ struct DefaultImport {
 }
 
 #[derive(Debug, PartialEq)]
-struct NamedImport<> {
+struct NamedImport {
     variable_name: String,
     binding_name: String,
 }
 
 #[derive(Debug, PartialEq)]
 enum NextToken {
-  Specifier,
-  DefaultImport,
-  DefaultExport,
-  NamedImport,
-  NamedExport,
-  StatementEnd,
-  Continue,
+    Specifier,
+    DefaultImport,
+    DefaultExport,
+    NamedImport,
+    NamedExport,
+    StatementEnd,
+    Continue,
 }
 
 #[derive(Debug)]
@@ -89,7 +89,7 @@ struct DefaultExport {
 }
 
 #[derive(Debug, PartialEq)]
-struct NamedExport<> {
+struct NamedExport {
     variable_name: String,
     binding_name: String,
 }
@@ -99,7 +99,7 @@ pub(crate) struct Parser<'l, 'a> {
     pending_import: Option<PendingImport>,
     pending_export: Option<PendingExport>,
     next_token: NextToken,
-    cursor: usize
+    cursor: usize,
 }
 
 impl<'l, 'a> Parser<'l, 'a> {
@@ -117,7 +117,7 @@ impl<'l, 'a> Parser<'l, 'a> {
         let mut js_module = JavascriptModule {
             imports: Vec::new(),
             exports: Vec::new(),
-            raw_source
+            raw_source,
         };
 
         for Token { kind, text } in self.tokens {
@@ -127,18 +127,18 @@ impl<'l, 'a> Parser<'l, 'a> {
                         import: JavascriptImport::new(),
                     });
                     self.next_token = NextToken::DefaultImport;
-                },
+                }
                 TokenKind::Export => {
                     self.pending_export = Some(PendingExport {
                         export: JavascriptExport::new(),
                     });
                     self.next_token = NextToken::DefaultExport;
-                },
+                }
                 TokenKind::From => {
                     if self.pending_import_or_export() {
                         self.next_token = NextToken::Specifier;
                     }
-                },
+                }
                 TokenKind::Ident => {
                     if self.pending_import.is_some() {
                         let mut pending_import = self.pending_import.as_mut().unwrap();
@@ -147,15 +147,15 @@ impl<'l, 'a> Parser<'l, 'a> {
                             NextToken::NamedImport => {
                                 pending_import.import.named_imports.push(NamedImport {
                                     variable_name: text.to_string(),
-                                    binding_name: text.to_string()
+                                    binding_name: text.to_string(),
                                 });
-                            },
+                            }
                             NextToken::DefaultImport => {
                                 pending_import.import.default_import = Some(DefaultImport {
                                     variable_name: text.to_string(),
-                                    binding_name: text.to_string()
+                                    binding_name: text.to_string(),
                                 });
-                            },
+                            }
                             _ => {}
                         }
                     } else if self.pending_export.is_some() {
@@ -165,61 +165,65 @@ impl<'l, 'a> Parser<'l, 'a> {
                             NextToken::NamedExport => {
                                 pending_export.export.named_exports.push(NamedExport {
                                     variable_name: text.to_string(),
-                                    binding_name: text.to_string()
+                                    binding_name: text.to_string(),
                                 });
-                            },
+                            }
                             NextToken::DefaultExport => {
                                 pending_export.export.default_export = Some(DefaultExport {
                                     variable_name: text.to_string(),
-                                    binding_name: text.to_string()
+                                    binding_name: text.to_string(),
                                 });
-                            },
+                            }
                             _ => {}
                         }
                     }
-                },
+                }
                 TokenKind::LBrace | TokenKind::Comma => {
                     if self.pending_import.is_some() {
                         self.next_token = NextToken::NamedImport;
                     } else if self.pending_export.is_some() {
                         self.next_token = NextToken::NamedExport;
                     }
-                },
+                }
                 TokenKind::RBrace => {
                     if self.pending_import_or_export() {
                         self.next_token = NextToken::Specifier;
                     }
-                },
-                TokenKind::Default => {},
-                TokenKind::As => {},
-                TokenKind::Star => {},
-                TokenKind::Error => {},
+                }
+                TokenKind::Default => {}
+                TokenKind::As => {}
+                TokenKind::Star => {}
+                TokenKind::Error => {}
                 TokenKind::Specifier => {
                     if self.pending_import.is_some() {
                         let mut pending_import = self.pending_import.as_mut().unwrap();
-                        pending_import.import.specifier = text[1..text.len()-1].to_string();
+                        pending_import.import.specifier = text[1..text.len() - 1].to_string();
                         pending_import.import.specifier_start = self.cursor;
                         pending_import.import.specifier_end = self.cursor + text.len();
                         self.next_token = NextToken::StatementEnd;
                     } else if self.pending_export.is_some() {
                         let mut pending_export = self.pending_export.as_mut().unwrap();
-                        pending_export.export.specifier = text[1..text.len()-1].to_string();
+                        pending_export.export.specifier = text[1..text.len() - 1].to_string();
                         pending_export.export.specifier_start = self.cursor;
                         pending_export.export.specifier_end = self.cursor + text.len();
                         self.next_token = NextToken::StatementEnd;
                     }
-                },
+                }
                 TokenKind::Semicolon | TokenKind::Whitespace => {
                     if self.next_token == NextToken::StatementEnd {
                         if self.pending_import.is_some() {
-                            js_module.imports.push(self.pending_import.take().unwrap().import);
+                            js_module
+                                .imports
+                                .push(self.pending_import.take().unwrap().import);
                         } else if self.pending_export.is_some() {
-                            js_module.exports.push(self.pending_export.take().unwrap().export);
+                            js_module
+                                .exports
+                                .push(self.pending_export.take().unwrap().export);
                         }
                         // we are done with this import or export.  Search for more
                         self.next_token = NextToken::Continue;
                     }
-                },
+                }
             }
 
             self.cursor += text.len();
@@ -248,8 +252,12 @@ import A from './a.js';
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 1);
         assert_eq!(module.exports.len(), 0);
-        assert_eq!(module.imports[0].default_import, Some(
-            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.imports[0].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.imports[0].named_imports, []);
         assert_eq!(module.imports[0].specifier, "./a.js");
@@ -268,8 +276,12 @@ import A from \"./a.js\";
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 1);
         assert_eq!(module.exports.len(), 0);
-        assert_eq!(module.imports[0].default_import, Some(
-            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.imports[0].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.imports[0].named_imports, []);
         assert_eq!(module.imports[0].specifier, "./a.js");
@@ -277,7 +289,6 @@ import A from \"./a.js\";
         assert_eq!(module.imports[0].specifier_end, 23);
         assert_eq!(module.raw_source, source.to_string());
     }
-
 
     #[test]
     fn parses_without_ending_semicolon() {
@@ -287,8 +298,12 @@ import A from './a.js'
         let tokens: Vec<_> = JavascriptLexer::new(&source).collect();
         let parser = Parser::new(&tokens);
         let module = parser.parse_module(source.to_string());
-        assert_eq!(module.imports[0].default_import, Some(
-            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.imports[0].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.imports[0].named_imports, []);
         assert_eq!(module.imports[0].specifier, "./a.js");
@@ -306,20 +321,42 @@ import C, { d, e } from './c.js';
         let parser = Parser::new(&tokens);
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 2);
-        assert_eq!(module.imports[0].default_import, Some(
-            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.imports[0].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.imports[0].named_imports.len(), 2);
-        assert_eq!(module.imports[0].named_imports, [
-            NamedImport { variable_name: String::from("a"), binding_name: String::from("a") },
-            NamedImport { variable_name: String::from("b"), binding_name: String::from("b") }
-        ]);
+        assert_eq!(
+            module.imports[0].named_imports,
+            [
+                NamedImport {
+                    variable_name: String::from("a"),
+                    binding_name: String::from("a")
+                },
+                NamedImport {
+                    variable_name: String::from("b"),
+                    binding_name: String::from("b")
+                }
+            ]
+        );
         assert_eq!(module.imports[0].specifier, "./a.js");
         assert_eq!(module.imports[1].named_imports.len(), 2);
-        assert_eq!(module.imports[1].named_imports, [
-            NamedImport { variable_name: String::from("d"), binding_name: String::from("d") },
-            NamedImport { variable_name: String::from("e"), binding_name: String::from("e") }
-        ]);
+        assert_eq!(
+            module.imports[1].named_imports,
+            [
+                NamedImport {
+                    variable_name: String::from("d"),
+                    binding_name: String::from("d")
+                },
+                NamedImport {
+                    variable_name: String::from("e"),
+                    binding_name: String::from("e")
+                }
+            ]
+        );
     }
 
     #[test]
@@ -332,7 +369,13 @@ import { a } from './a.js';
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 1);
         assert_eq!(module.imports[0].default_import, None);
-        assert_eq!(module.imports[0].named_imports, [NamedImport { variable_name: String::from("a"), binding_name: String::from("a") }]);
+        assert_eq!(
+            module.imports[0].named_imports,
+            [NamedImport {
+                variable_name: String::from("a"),
+                binding_name: String::from("a")
+            }]
+        );
         assert_eq!(module.imports[0].specifier, "./a.js");
     }
 
@@ -346,10 +389,19 @@ import { a, b } from './a.js';
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 1);
         assert_eq!(module.imports[0].default_import, None);
-        assert_eq!(module.imports[0].named_imports, [
-            NamedImport { variable_name: String::from("a"), binding_name: String::from("a") },
-            NamedImport { variable_name: String::from("b"), binding_name: String::from("b") }
-        ]);
+        assert_eq!(
+            module.imports[0].named_imports,
+            [
+                NamedImport {
+                    variable_name: String::from("a"),
+                    binding_name: String::from("a")
+                },
+                NamedImport {
+                    variable_name: String::from("b"),
+                    binding_name: String::from("b")
+                }
+            ]
+        );
         assert_eq!(module.imports[0].specifier, "./a.js");
     }
 
@@ -362,13 +414,26 @@ import A, { a, b } from './a.js';
         let parser = Parser::new(&tokens);
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 1);
-        assert_eq!(module.imports[0].default_import, Some(
-            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.imports[0].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
-        assert_eq!(module.imports[0].named_imports, [
-            NamedImport { variable_name: String::from("a"), binding_name: String::from("a") },
-            NamedImport { variable_name: String::from("b"), binding_name: String::from("b") }
-        ]);
+        assert_eq!(
+            module.imports[0].named_imports,
+            [
+                NamedImport {
+                    variable_name: String::from("a"),
+                    binding_name: String::from("a")
+                },
+                NamedImport {
+                    variable_name: String::from("b"),
+                    binding_name: String::from("b")
+                }
+            ]
+        );
         assert_eq!(module.imports[0].specifier, "./a.js");
     }
 
@@ -382,8 +447,12 @@ export A from './a.js';
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 0);
         assert_eq!(module.exports.len(), 1);
-        assert_eq!(module.exports[0].default_export, Some(
-            DefaultExport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.exports[0].default_export,
+            Some(DefaultExport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.exports[0].named_exports, []);
         assert_eq!(module.exports[0].specifier, "./a.js");
@@ -403,10 +472,19 @@ export { d, E } from './d.js';
         assert_eq!(module.imports.len(), 0);
         assert_eq!(module.exports.len(), 1);
         assert_eq!(module.exports[0].default_export, None);
-        assert_eq!(module.exports[0].named_exports, [
-            NamedExport { variable_name: String::from("d"), binding_name: String::from("d") },
-            NamedExport { variable_name: String::from("E"), binding_name: String::from("E") }
-        ]);
+        assert_eq!(
+            module.exports[0].named_exports,
+            [
+                NamedExport {
+                    variable_name: String::from("d"),
+                    binding_name: String::from("d")
+                },
+                NamedExport {
+                    variable_name: String::from("E"),
+                    binding_name: String::from("E")
+                }
+            ]
+        );
         assert_eq!(module.exports[0].specifier, "./d.js");
         assert_eq!(module.exports[0].specifier_start, 22);
         assert_eq!(module.exports[0].specifier_end, 30);
@@ -424,9 +502,13 @@ export { b as default } from './b.js';
         assert_eq!(module.imports.len(), 0);
         assert_eq!(module.exports.len(), 1);
         assert_eq!(module.exports[0].default_export, None);
-        assert_eq!(module.exports[0].named_exports, [
-            NamedExport { variable_name: String::from("b"), binding_name: String::from("b") },
-        ]);
+        assert_eq!(
+            module.exports[0].named_exports,
+            [NamedExport {
+                variable_name: String::from("b"),
+                binding_name: String::from("b")
+            },]
+        );
         assert_eq!(module.exports[0].specifier, "./b.js");
         assert_eq!(module.exports[0].specifier_start, 30);
         assert_eq!(module.exports[0].specifier_end, 38);
@@ -444,9 +526,13 @@ export { default as b } from './b.js';
         assert_eq!(module.imports.len(), 0);
         assert_eq!(module.exports.len(), 1);
         assert_eq!(module.exports[0].default_export, None);
-        assert_eq!(module.exports[0].named_exports, [
-            NamedExport { variable_name: String::from("b"), binding_name: String::from("b") },
-        ]);
+        assert_eq!(
+            module.exports[0].named_exports,
+            [NamedExport {
+                variable_name: String::from("b"),
+                binding_name: String::from("b")
+            },]
+        );
         assert_eq!(module.exports[0].specifier, "./b.js");
         assert_eq!(module.exports[0].specifier_start, 30);
         assert_eq!(module.exports[0].specifier_end, 38);
@@ -483,15 +569,28 @@ export A from './a.js';
         assert_eq!(module.imports.len(), 0);
         assert_eq!(module.exports.len(), 2);
         assert_eq!(module.exports[0].default_export, None);
-        assert_eq!(module.exports[0].named_exports, [
-            NamedExport { variable_name: String::from("d"), binding_name: String::from("d") },
-            NamedExport { variable_name: String::from("E"), binding_name: String::from("E") }
-        ]);
+        assert_eq!(
+            module.exports[0].named_exports,
+            [
+                NamedExport {
+                    variable_name: String::from("d"),
+                    binding_name: String::from("d")
+                },
+                NamedExport {
+                    variable_name: String::from("E"),
+                    binding_name: String::from("E")
+                }
+            ]
+        );
         assert_eq!(module.exports[0].specifier, "./d.js");
         assert_eq!(module.exports[0].specifier_start, 22);
         assert_eq!(module.exports[0].specifier_end, 30);
-        assert_eq!(module.exports[1].default_export, Some(
-            DefaultExport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.exports[1].default_export,
+            Some(DefaultExport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.exports[1].named_exports, []);
         assert_eq!(module.exports[1].specifier, "./a.js");
@@ -512,16 +611,24 @@ export { A as default } from './a-default.js';
         assert_eq!(module.imports.len(), 0);
         assert_eq!(module.exports.len(), 2);
         assert_eq!(module.exports[0].default_export, None);
-        assert_eq!(module.exports[0].named_exports, [
-            NamedExport { variable_name: String::from("DModule"), binding_name: String::from("DModule") },
-        ]);
+        assert_eq!(
+            module.exports[0].named_exports,
+            [NamedExport {
+                variable_name: String::from("DModule"),
+                binding_name: String::from("DModule")
+            },]
+        );
         assert_eq!(module.exports[0].specifier, "./d.js");
         assert_eq!(module.exports[0].specifier_start, 36);
         assert_eq!(module.exports[0].specifier_end, 44);
         assert_eq!(module.exports[1].default_export, None);
-        assert_eq!(module.exports[1].named_exports, [
-            NamedExport { variable_name: String::from("A"), binding_name: String::from("A") },
-        ]);
+        assert_eq!(
+            module.exports[1].named_exports,
+            [NamedExport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            },]
+        );
         assert_eq!(module.exports[1].specifier, "./a-default.js");
         assert_eq!(module.exports[1].specifier_start, 75);
         assert_eq!(module.exports[1].specifier_end, 91);
@@ -568,12 +675,20 @@ export E from './e.js';
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 1);
         assert_eq!(module.exports.len(), 1);
-        assert_eq!(module.imports[0].default_import, Some(
-            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.imports[0].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.imports[0].named_imports, []);
-        assert_eq!(module.exports[0].default_export, Some(
-            DefaultExport { variable_name: String::from("E"), binding_name: String::from("E") })
+        assert_eq!(
+            module.exports[0].default_export,
+            Some(DefaultExport {
+                variable_name: String::from("E"),
+                binding_name: String::from("E")
+            })
         );
         assert_eq!(module.exports[0].named_exports, []);
         assert_eq!(module.exports[0].specifier, "./e.js");
@@ -596,16 +711,24 @@ export E from './e.js';
 
         assert_eq!(module.imports.len(), 1);
         assert_eq!(module.exports.len(), 1);
-        assert_eq!(module.imports[0].default_import, Some(
-            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.imports[0].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.imports[0].named_imports, []);
         assert_eq!(module.imports[0].specifier, "./a.js");
         assert_eq!(module.imports[0].specifier_start, 15);
         assert_eq!(module.imports[0].specifier_end, 23);
 
-        assert_eq!(module.exports[0].default_export, Some(
-            DefaultExport { variable_name: String::from("E"), binding_name: String::from("E") })
+        assert_eq!(
+            module.exports[0].default_export,
+            Some(DefaultExport {
+                variable_name: String::from("E"),
+                binding_name: String::from("E")
+            })
         );
         assert_eq!(module.exports[0].named_exports, []);
         assert_eq!(module.exports[0].specifier, "./e.js");
@@ -627,8 +750,12 @@ import C from './c.js'; /** test-comment */
         let module = parser.parse_module(source.to_string());
         assert_eq!(module.imports.len(), 3);
         assert_eq!(module.exports.len(), 0);
-        assert_eq!(module.imports[0].default_import, Some(
-            DefaultImport { variable_name: String::from("A"), binding_name: String::from("A") })
+        assert_eq!(
+            module.imports[0].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("A"),
+                binding_name: String::from("A")
+            })
         );
         assert_eq!(module.imports[0].named_imports, []);
         assert_eq!(module.imports[0].specifier, "./a.js");
@@ -636,8 +763,12 @@ import C from './c.js'; /** test-comment */
         assert_eq!(module.imports[0].specifier_end, 23);
         assert_eq!(module.raw_source, source.to_string());
 
-        assert_eq!(module.imports[1].default_import, Some(
-            DefaultImport { variable_name: String::from("B"), binding_name: String::from("B") })
+        assert_eq!(
+            module.imports[1].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("B"),
+                binding_name: String::from("B")
+            })
         );
         assert_eq!(module.imports[1].named_imports, []);
         assert_eq!(module.imports[1].specifier, "./b.js");
@@ -645,8 +776,12 @@ import C from './c.js'; /** test-comment */
         assert_eq!(module.imports[1].specifier_end, 82);
         assert_eq!(module.raw_source, source.to_string());
 
-        assert_eq!(module.imports[2].default_import, Some(
-            DefaultImport { variable_name: String::from("C"), binding_name: String::from("C") })
+        assert_eq!(
+            module.imports[2].default_import,
+            Some(DefaultImport {
+                variable_name: String::from("C"),
+                binding_name: String::from("C")
+            })
         );
         assert_eq!(module.imports[2].named_imports, []);
         assert_eq!(module.imports[2].specifier, "./c.js");
@@ -654,5 +789,4 @@ import C from './c.js'; /** test-comment */
         assert_eq!(module.imports[2].specifier_end, 106);
         assert_eq!(module.raw_source, source.to_string());
     }
-
 }

--- a/test/fixtures/bundle.js
+++ b/test/fixtures/bundle.js
@@ -26,9 +26,12 @@ insertModule("test/fixtures/src/c-default.js",createModuleUrl(`const c = 'defaul
 
 export default c;
 `));
-insertModule("test/fixtures/src/main.js",createModuleUrl(`import A, { a, b, DModule, e } from '${resolveImportSpecifier("test/fixtures/src/a.js")}';
+insertModule("test/fixtures/src/main.js",createModuleUrl(`import A, { a, b, DModule, e } from '${resolveImportSpecifier("test/fixtures/src/a.js")}'; // test-comment
 import c from '${resolveImportSpecifier("test/fixtures/src/c-default.js")}';
 
+/**
+ * Make sure this shows up in the console
+ */
 console.log('hi there', A, a, b, c, DModule, e);
 `));
 import(resolveImportSpecifier("test/fixtures/src/main.js"));

--- a/test/fixtures/src/main.js
+++ b/test/fixtures/src/main.js
@@ -1,4 +1,7 @@
-import A, { a, b, DModule, e } from './a.js';
+import A, { a, b, DModule, e } from './a.js'; // test-comment
 import c from './c-default.js';
 
+/**
+ * Make sure this shows up in the console
+ */
 console.log('hi there', A, a, b, c, DModule, e);


### PR DESCRIPTION
Hi!  I've put this PR in **draft** to not presume this is a path you want to take this project. 

Overall, the reason why I thought I might submit this work is the main parsing logic has reduced from ~425 lines to ~115 lines.

I came to this solution though trying to handle comments.  Parsing character by character was requiring me to take some excessive steps to handle.  Moreover, I saw a few other places we could improve our logic.  By using [Logos](https://github.com/maciejhirsz/logos), we get a fast tokenizer

```
#[regex("[ \n]+")]
Whitespace,

#[token("import")]
Import,
```

and then send the Vec of tokens to the parser.  Moreover, if we plan to represent every JS construct (bindings, statements, etc), I thought it would be best to abstract away.

To verify nothing has changed about this new implementation, see diff for `bundle.js`.  Let me know if there is anything else you would like me to go over!